### PR TITLE
fix(skills): install Claude skills as <id>/SKILL.md with parseable frontmatter

### DIFF
--- a/npm/kaboom-agentic-browser/lib/skills.js
+++ b/npm/kaboom-agentic-browser/lib/skills.js
@@ -410,8 +410,14 @@ async function loadSkillCatalog(options = {}) {
   }
 }
 
+// The marker is appended, not prepended. Skill bodies begin with YAML frontmatter,
+// which must start on line 1; a leading HTML comment pushes the opening `---` down
+// and the frontmatter no longer parses, so `name`/`description` never resolve.
 function buildManagedContent(skillId, version, body) {
-  return `${MANAGED_MARKER} id:${skillId} version:${version} -->\n${body}`;
+  const text = String(body == null ? '' : body);
+  const marker = `${MANAGED_MARKER} id:${skillId} version:${version} -->`;
+  const separator = text.length === 0 || text.endsWith('\n') ? '' : '\n';
+  return `${text}${separator}${marker}\n`;
 }
 
 function isManagedSkillContent(content) {
@@ -448,11 +454,46 @@ function safeWriteManagedFile(filePath, content) {
   }
 }
 
+// Agents whose skill loader discovers `<root>/<id>/SKILL.md` rather than a flat
+// `<root>/<id>.md`. Claude Code only scans the directory form, so a flat file is
+// written successfully but never registered as a skill.
+function usesDirectorySkillLayout(agent) {
+  return agent === 'codex' || agent === 'claude';
+}
+
 function skillFilePath(agent, rootDir, skillId) {
-  if (agent === 'codex') {
+  if (usesDirectorySkillLayout(agent)) {
     return path.join(rootDir, skillId, 'SKILL.md');
   }
   return path.join(rootDir, `${skillId}.md`);
+}
+
+// Path used before the directory layout was adopted for an agent. Retained so the
+// cleanup sweep can still find skills installed by an older version, which would
+// otherwise be orphaned in the user's working tree.
+function legacyFlatSkillFilePath(rootDir, skillId) {
+  return path.join(rootDir, `${skillId}.md`);
+}
+
+// Removes a flat `<id>.md` left by a release that predates the directory layout for
+// this agent. Without this the old file survives beside the new `<id>/SKILL.md`,
+// stays untracked in the user's repo, and is never cleaned up by any later run.
+function removeLegacyFlatSkillFile(agent, rootDir, skillId, options = {}) {
+  const { dryRun = false } = options;
+  if (!usesDirectorySkillLayout(agent)) return 0;
+
+  const flatPath = legacyFlatSkillFilePath(rootDir, skillId);
+  if (!fs.existsSync(flatPath)) return 0;
+
+  try {
+    const existing = fs.readFileSync(flatPath, 'utf8');
+    // Only reclaim files this installer wrote — never a user-authored skill.
+    if (!isManagedSkillContent(existing)) return 0;
+    if (!dryRun) fs.unlinkSync(flatPath);
+    return 1;
+  } catch (_) {
+    return 0;
+  }
 }
 
 function removeManagedSkillFile(agent, rootDir, skillId, options = {}) {
@@ -469,7 +510,7 @@ function removeManagedSkillFile(agent, rootDir, skillId, options = {}) {
     }
     if (!dryRun) {
       fs.unlinkSync(managedPath);
-      if (agent === 'codex') {
+      if (path.basename(managedPath) === 'SKILL.md') {
         const managedDir = path.dirname(managedPath);
         try {
           fs.rmdirSync(managedDir);
@@ -518,9 +559,12 @@ function removeLegacySkillVariants(agent, rootDir, skillId, options = {}) {
   return removed;
 }
 
+// Matches the marker at the start of any line, so files written by older releases
+// (marker first) and current ones (marker last) are both recognised. Anchoring to a
+// line start keeps this from matching a marker merely quoted inside prose.
 function isManagedSkillFileStart(content) {
   const text = String(content || '');
-  return MANAGED_MARKERS.some((marker) => text.startsWith(marker));
+  return MANAGED_MARKERS.some((marker) => text.startsWith(marker) || text.includes(`\n${marker}`));
 }
 
 /**
@@ -542,8 +586,13 @@ function removeOrphanedManagedSkills(agent, rootDir, handledPaths, options = {})
 
   for (const entry of entries) {
     let candidate = null;
-    if (agent === 'codex') {
-      if (entry.isDirectory()) candidate = path.join(rootDir, entry.name, 'SKILL.md');
+    if (usesDirectorySkillLayout(agent)) {
+      if (entry.isDirectory()) {
+        candidate = path.join(rootDir, entry.name, 'SKILL.md');
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        // Flat file left by a release that predates the directory layout.
+        candidate = path.join(rootDir, entry.name);
+      }
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
       candidate = path.join(rootDir, entry.name);
     }
@@ -554,7 +603,9 @@ function removeOrphanedManagedSkills(agent, rootDir, handledPaths, options = {})
       if (!isManagedSkillFileStart(content)) continue;
       if (!dryRun) {
         fs.unlinkSync(candidate);
-        if (agent === 'codex') {
+        // Only prune the parent for the directory layout; a legacy flat file's
+        // parent is the skills root itself and must never be removed.
+        if (path.basename(candidate) === 'SKILL.md') {
           try {
             fs.rmdirSync(path.dirname(candidate));
           } catch (_) {
@@ -702,6 +753,7 @@ async function installBundledSkills(options = {}) {
           );
         }
         summary.legacy_removed += removeLegacySkillVariants(agent, rootDir, skill.id);
+        summary.legacy_removed += removeLegacyFlatSkillFile(agent, rootDir, skill.id);
       }
     }
   }

--- a/npm/kaboom-agentic-browser/lib/skills.test.js
+++ b/npm/kaboom-agentic-browser/lib/skills.test.js
@@ -118,7 +118,7 @@ test('installBundledSkills only installs into agent dirs that already exist', as
 
     assert.equal(result.skipped, false);
     assert.equal(
-      fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'demo.md')),
+      fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'demo', 'SKILL.md')),
       true,
       'must install into the existing .claude layout'
     );
@@ -144,7 +144,7 @@ test('installBundledSkills force-creates explicit env-var skill targets', async 
 
     assert.equal(result.skipped, false);
     assert.equal(
-      fs.existsSync(path.join(forcedRoot, 'demo.md')),
+      fs.existsSync(path.join(forcedRoot, 'demo', 'SKILL.md')),
       true,
       'explicit env-var target must be created even when its parent did not exist'
     );
@@ -244,6 +244,172 @@ test('cleanupInstalledSkills dry-run counts orphans without deleting and without
     assert.equal(result.removed, 2, 'dry-run must count each managed file exactly once');
     assert.equal(fs.existsSync(path.join(claudeRoot, 'debug.md')), true);
     assert.equal(fs.existsSync(path.join(claudeRoot, 'orphan.md')), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- Claude skill layout (regression: flat <id>.md was never discovered) ---
+
+function makeFrontmatterSkillsFixture(tmp) {
+  const skillsDir = path.join(tmp, 'bundled-fm');
+  fs.mkdirSync(path.join(skillsDir, 'demo'), { recursive: true });
+  fs.writeFileSync(
+    path.join(skillsDir, 'skills.json'),
+    JSON.stringify({ skills: [{ id: 'demo', version: 3 }] }),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(skillsDir, 'demo', 'SKILL.md'),
+    '---\nname: demo\ndescription: Demo skill.\n---\n\n# Demo\nbody\n',
+    'utf8'
+  );
+  return skillsDir;
+}
+
+test('installBundledSkills writes claude skills as <id>/SKILL.md, not a flat <id>.md', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-claude-layout-'));
+  try {
+    const root = path.join(tmp, 'claude-skills');
+    const skillsDir = makeSkillsFixture(tmp);
+
+    await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: root }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir })
+    );
+
+    assert.equal(
+      fs.existsSync(path.join(root, 'demo', 'SKILL.md')),
+      true,
+      'claude discovers <root>/<id>/SKILL.md and must be installed there'
+    );
+    assert.equal(
+      fs.existsSync(path.join(root, 'demo.md')),
+      false,
+      'a flat <id>.md is never scanned by claude and must not be written'
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills keeps YAML frontmatter on line 1', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-frontmatter-'));
+  try {
+    const root = path.join(tmp, 'claude-skills');
+    const skillsDir = makeFrontmatterSkillsFixture(tmp);
+
+    await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: root }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir })
+    );
+
+    const written = fs.readFileSync(path.join(root, 'demo', 'SKILL.md'), 'utf8');
+    assert.equal(
+      written.startsWith('---'),
+      true,
+      'frontmatter must open on line 1 or the loader cannot parse name/description'
+    );
+    assert.equal(
+      written.includes('<!-- kaboom-managed-skill id:demo'),
+      true,
+      'the managed marker must still be present so cleanup can identify the file'
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills removes a legacy flat claude skill left by an older version', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-legacy-flat-'));
+  try {
+    const root = path.join(tmp, 'claude-skills');
+    fs.mkdirSync(root, { recursive: true });
+    const legacyFlat = path.join(root, 'demo.md');
+    fs.writeFileSync(
+      legacyFlat,
+      '<!-- kaboom-managed-skill id:demo version:1 -->\n---\nname: demo\n---\nold\n',
+      'utf8'
+    );
+    const skillsDir = makeSkillsFixture(tmp);
+
+    await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: root }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir })
+    );
+
+    assert.equal(
+      fs.existsSync(legacyFlat),
+      false,
+      'the pre-existing flat file must be reclaimed, not orphaned beside the new one'
+    );
+    assert.equal(fs.existsSync(path.join(root, 'demo', 'SKILL.md')), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills leaves a user-authored flat file alone', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-user-flat-'));
+  try {
+    const root = path.join(tmp, 'claude-skills');
+    fs.mkdirSync(root, { recursive: true });
+    const userFile = path.join(root, 'demo.md');
+    fs.writeFileSync(userFile, '---\nname: demo\n---\nmine, not managed\n', 'utf8');
+    const skillsDir = makeSkillsFixture(tmp);
+
+    await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: root }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir })
+    );
+
+    assert.equal(
+      fs.readFileSync(userFile, 'utf8').includes('mine, not managed'),
+      true,
+      'a file without the managed marker is user-owned and must never be deleted'
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('cleanupInstalledSkills removes orphaned claude skill directories', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-claude-cleanup-'));
+  try {
+    const root = path.join(tmp, 'claude-skills');
+    fs.mkdirSync(path.join(root, 'gone'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'gone', 'SKILL.md'),
+      '---\nname: gone\n---\nbody\n<!-- kaboom-managed-skill id:gone version:1 -->\n',
+      'utf8'
+    );
+    const skillsDir = makeSkillsFixture(tmp);
+
+    await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: root }, () =>
+      cleanupInstalledSkills({ agents: ['claude'], scope: 'global', skillsDir })
+    );
+
+    assert.equal(
+      fs.existsSync(path.join(root, 'gone', 'SKILL.md')),
+      false,
+      'a managed skill no longer in the manifest must be removed at the new path too'
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills leaves the gemini flat layout unchanged', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-gemini-layout-'));
+  try {
+    const root = path.join(tmp, 'gemini-skills');
+    const skillsDir = makeSkillsFixture(tmp);
+
+    await withEnv({ KABOOM_GEMINI_SKILLS_DIR: root }, () =>
+      installBundledSkills({ agents: ['gemini'], scope: 'global', skillsDir })
+    );
+
+    assert.equal(
+      fs.existsSync(path.join(root, 'demo.md')),
+      true,
+      'gemini layout is unchanged by this fix'
+    );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes #696.

## What was broken

Installing skills for the `claude` agent wrote 16 files successfully and Claude Code registered **none** of them. Two independent defects, either one sufficient on its own.

### 1. `skillFilePath()` gave the directory layout to `codex` only

```js
if (agent === 'codex') {
  return path.join(rootDir, skillId, 'SKILL.md');
}
return path.join(rootDir, `${skillId}.md`);   // claude landed here
```

Claude Code discovers skills at `<root>/<id>/SKILL.md`. A flat `<id>.md` is written without error and never scanned.

The directory shape was already known in this same file — it is built for the manifest default path and read by the cleanup walk when it encounters a directory. **The writer and the reader disagreed.** `claude_skill/install.sh` is also already correct (`.claude/skills/kaboom/SKILL.md`), so the shell installer and the npm installer disagreed with each other too.

### 2. `buildManagedContent()` prepended the marker ahead of the frontmatter

```js
return `${MANAGED_MARKER} id:${skillId} version:${version} -->\n${body}`;
```

`body` opens with `---`. Prepending pushed it to line 2, so the frontmatter did not parse and `name`/`description` never resolved. The marker is now appended.

## Why the change is larger than two lines

Three follow-on edits are required to keep the module self-consistent — each of them, omitted, would break something that currently works:

- **The orphan sweep had its own `agent === 'codex'` branch.** Changing the write path alone would leave cleanup hunting for `<id>.md` while the installer wrote `<id>/SKILL.md`, making managed skills undeletable.
- **`isManagedSkillFileStart()` used `startsWith()`**, which stops matching once the marker trails the content. It now matches at any line start. That covers files from older releases (marker first) and current ones (marker last), and anchoring to a line start preserves the existing guarantee — already covered by a test in this file — that a document merely *mentioning* the marker mid-line is treated as user-owned.
- **A flat `<id>.md` from an earlier release is now reclaimed on install.** Without this the stale file survives beside the new one and no later run removes it. It matters more than it looks: these files land in a git working tree, and an untracked file keeps `git status` dirty, which makes `git merge --ff-only` abort.

Directory pruning is now keyed on the filename being `SKILL.md` rather than on the agent, so a legacy flat file can never cause its parent — the skills root itself — to be removed.

Reclaiming only happens for files carrying the managed marker; a user-authored `<id>.md` is left alone, and there is a test for it.

## Scope

`gemini` behaviour is unchanged — only `claude` gains the directory layout. I did not touch the Go code, the extension, or `claude_skill/install.sh`.

## Tests

`npm/kaboom-agentic-browser/lib/skills.test.js` gains six cases:

| Test | Guards |
|---|---|
| writes `<id>/SKILL.md`, not flat `<id>.md` | defect 1 |
| written file starts with `---` | defect 2 |
| legacy flat file reclaimed on install | migration |
| user-authored flat file survives | over-reach |
| cleanup removes an orphaned claude directory | sweep agreement |
| gemini layout unchanged | regression |

Two existing assertions moved from `<id>.md` to `<id>/SKILL.md`. Their stated intent — installing into an existing `.claude` layout, and force-creating an explicit env-var target — is unchanged; only the expected path shape differs.

**Verified both directions:** 6 of the 13 tests fail against the unmodified module, and all 13 pass with the fix.

```
# unmodified skills.js, new tests
ℹ tests 13   ℹ pass 7   ℹ fail 6

# with the fix
ℹ tests 13   ℹ pass 13   ℹ fail 0
```

The two that pass in both directions are the over-reach guards, which is expected — they assert nothing changed.

Happy to adjust the approach if you'd prefer the marker inside the frontmatter as an `x-` field rather than appended, or if `gemini` should move to the directory layout as well — I left it alone since I could not verify its loader's expectation.
