### PR TITLE
fix(skills): complete Claude directory migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
             echo "verify-llm gate not required for this PR."
           fi
 
+      - name: Install pinned Node toolchain
+        if: steps.scope.outputs.run_gate == 'true'
+        run: npm ci
+
       - name: Run verify-llm gate
         if: steps.scope.outputs.run_gate == 'true'
         run: make verify-llm

--- a/docs/features/feature/design-drift-audit/index.md
+++ b/docs/features/feature/design-drift-audit/index.md
@@ -4,7 +4,7 @@ feature_id: feature-design-drift-audit
 status: shipped
 feature_type: feature
 owners: []
-last_reviewed: 2026-08-22
+last_reviewed: 2026-08-29
 code_paths:
   - cmd/browser-agent/internal/toolanalyze/designdrift/handler.go
   - cmd/browser-agent/internal/toolanalyze/designdrift/finding.go
@@ -18,6 +18,7 @@ code_paths:
   - internal/tools/configure/capabilities/modespecs_analyze.go
   - src/inject/computed-styles.ts
   - src/types/wire/wire-style-probe.ts
+  - gokaboom.dev/src/content/docs/reference/analyze.md
 test_paths:
   - cmd/browser-agent/internal/toolanalyze/designdrift/contract_test.go
   - cmd/browser-agent/internal/toolanalyze/designdrift/analyzers_test.go
@@ -26,6 +27,7 @@ test_paths:
   - cmd/browser-agent/internal/toolanalyze/designdrift/testdata/fixture-probe.json
   - cmd/browser-agent/internal/testpages/pages/design-drift.html
   - scripts/tests/browser/cat-36-design-drift.sh
+  - scripts/docs/reference/check-reference-schema-sync.mjs
 ---
 
 # Design Drift Audit

--- a/docs/features/feature/enhanced-cli-config/index.md
+++ b/docs/features/feature/enhanced-cli-config/index.md
@@ -4,7 +4,7 @@ feature_id: feature-enhanced-cli-config
 status: proposed
 feature_type: feature
 owners: []
-last_reviewed: 2026-08-25
+last_reviewed: 2026-08-29
 code_paths:
   - cmd/browser-agent/internal/runtimeflags/flags.go
   - internal/serverdefaults/defaults.go
@@ -139,6 +139,7 @@ test_paths:
   - scripts/release/npm-wrapper/run-tests.test.mjs
   - scripts/release/version/version-sync.test.mjs
   - tests/extension/contracts/tooling-contracts.test.js
+  - scripts/quality/contracts/check-bridge-stdout-invariant.sh
   - cmd/browser-agent/internal/cli/cli_test.go
   - cmd/browser-agent/internal/cli/cli_coverage_extra_test.go
 last_verified_version: 0.8.1
@@ -210,9 +211,10 @@ ownership boundary without compatibility wrappers.
   are preserved without migration-specific handling.
 - PyPI wrapper config helpers now converge on `merge_kaboom_config(...)`, and packaged `.egg-info` metadata now exposes only Kaboom package names, entry points, and repo URLs.
 - The npm wrapper recognizes, installs, diagnoses, approves, stops, and
-  uninstalls only canonical Kaboom identities and state paths. It does not
-  retain migration branches for historical server names, skill markers,
-  process names, config keys, config paths, or PID files.
+  uninstalls only canonical Kaboom identities and state paths. It exposes no
+  historical aliases or callable compatibility surfaces. Retired skill names
+  remain only as bounded, non-exported ownership data for deleting stale
+  installer-managed files during an upgrade.
 - The npm launcher library is divided by change ownership: `config/` owns
   client configuration and approval, `installation/` owns install/uninstall
   and bundled skills, `daemon/` owns health and process lifecycle, `browser/`
@@ -237,6 +239,10 @@ ownership boundary without compatibility wrappers.
   the launchers no longer probe `command -v`/`where`, and `resolveManagedBinaryPath`
   no longer returns a bare command name that clients resolved through PATH at spawn
   time. A missing platform package is an install fault and reports itself as one.
+- Installer unit tests inject a known executable instead of depending on a
+  source-tree `dist/` artifact, so upgrade guards exercise the same contracts on
+  clean Linux, macOS, and Windows checkouts. Scoped `verify-llm` CI installs the
+  pinned Node toolchain before running its canonical Make target.
 - Skill-install and doctor output report only fields produced by the canonical
   installers; obsolete legacy-removal counters and warning renderers are gone.
 - Server postinstall now validates `kaboom-browser-devtools` on `/health` reuse checks and points manual extension loading at `KABOOM_EXTENSION_DIR` / `~/KaboomAgenticDevtoolExtension`.
@@ -254,6 +260,12 @@ ownership boundary without compatibility wrappers.
 - Managed Codex skills keep YAML frontmatter as the first document block; the
   Kaboom ownership/version marker is inserted immediately after frontmatter so
   Codex validation and safe managed cleanup both recognize the installed file.
+- Managed Claude skills use the loader-discovered `<root>/<id>/SKILL.md`
+  layout and keep YAML frontmatter first in both npm and source-script installs.
+  The npm installer reclaims only marker-owned flat files from prior layouts—
+  including prefixed variants—and reports both removals and cleanup failures;
+  user-authored flat files survive unchanged. Gemini retains its flat
+  `<root>/<id>.md` layout.
 - Install now also fixes the Claude Code `claude mcp add-json` invocation (JSON passed as a positional arg, not stdin) and adds **Codex CLI** as a supported client (`~/.codex/config.toml`, TOML; honors `$CODEX_HOME`).
 - Native `--install` has the same Codex support as the npm entry point.
   `--install codex` selects Codex explicitly; unknown positional targets fail

--- a/gokaboom.dev/src/content/docs/reference/analyze.md
+++ b/gokaboom.dev/src/content/docs/reference/analyze.md
@@ -1,6 +1,6 @@
 ---
 title: "Analyze — Active Analysis"
-description: "Complete reference for the analyze tool. 28 modes for DOM queries, accessibility audits, security scans, link health, visual annotations, verification contracts, visual regression, form analysis, performance snapshots, and more."
+description: "Complete reference for the analyze tool. 32 modes for DOM queries, accessibility audits, security scans, link health, visual annotations, verification contracts, visual regression, form analysis, performance snapshots, and more."
 last_verified_version: 0.9.0
 last_verified_date: 2026-08-04
 normalized_tags: ['reference', 'analyze']
@@ -25,6 +25,7 @@ analyze({what: "performance"})                                       // Performa
 analyze({what: "error_clusters"})                                    // Group similar errors
 analyze({what: "page_summary"})                                      // Page structure
 analyze({what: "annotations", annot_session: "review"})             // Draw mode results
+analyze({what: "design_audit", selector: ".card"})                  // Find design drift
 analyze({what: "verification", operation: "define", contract: {...}}) // Define QA contract
 ```
 
@@ -474,6 +475,33 @@ Detect feature flags and feature gates on the page — A/B test variants, featur
 ```js
 analyze({what: "feature_gates"})
 ```
+
+### `design_audit`
+
+Compare a group of rendered elements for inconsistent typography and color,
+near-misses against design tokens, and uneven sibling spacing. Declared rules
+produce errors; values inferred from the peer majority produce warnings.
+
+```js
+analyze({what: "design_audit", selector: ".card"})
+analyze({what: "design_audit", selector: ".card", categories: ["spacing"]})
+analyze({
+  what: "design_audit",
+  selector: ".card",
+  spec: {
+    spacing_scale: [4, 8, 16, 24, 32],
+    font_families: ["Inter"],
+    colors: ["#2a55e1"],
+    font_sizes: [12, 14, 16]
+  }
+})
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `selector` | string (required) | CSS selector naming the peer group to compare |
+| `categories` | array | Any of `style_consistency`, `design_tokens`, and `spacing` |
+| `spec` | object | Optional declared `spacing_scale`, `font_families`, `colors`, and `font_sizes` |
 
 ## Verification Contracts
 

--- a/npm/kaboom-agentic-browser/lib/cli/cli.js
+++ b/npm/kaboom-agentic-browser/lib/cli/cli.js
@@ -163,7 +163,7 @@ async function installCommand(options) {
           console.log(
             `🧠 Skills installed (${skillInstall.agents.join(', ')} / ${skillInstall.scope}): ` +
             `source=${skillInstall.source}, created=${s.created}, updated=${s.updated}, unchanged=${s.unchanged}, ` +
-            `skipped=${s.skipped_user_owned}, errors=${s.errors}`
+            `skipped=${s.skipped_user_owned}, removed=${s.removed}, errors=${s.errors}`
           );
           for (const warning of skillInstall.warnings || []) {
             console.warn(`⚠️  ${warning}`);

--- a/npm/kaboom-agentic-browser/lib/config/config.test.js
+++ b/npm/kaboom-agentic-browser/lib/config/config.test.js
@@ -32,7 +32,7 @@ test('resolveManagedBinaryPath honors KABOOM_BINARY_PATH when it exists', () => 
 });
 
 test('resolveManagedBinaryPath finds the installed node_modules platform binary', () => {
-  const root = path.join(path.sep, 'proj', 'node_modules', 'kaboom-agentic-browser');
+  const root = path.resolve(path.sep, 'proj', 'node_modules', 'kaboom-agentic-browser');
   const expected = path.join(root, 'node_modules', '@brennhill/kaboom-agentic-browser-darwin-arm64', 'bin', 'kaboom-agentic-browser');
   const p = resolveManagedBinaryPath({
     env: {}, platform: 'darwin', arch: 'arm64', packageRoot: root,

--- a/npm/kaboom-agentic-browser/lib/contracts/no-compatibility.test.js
+++ b/npm/kaboom-agentic-browser/lib/contracts/no-compatibility.test.js
@@ -21,6 +21,15 @@ const canonicalModules = [
 ];
 
 const libRoot = path.resolve(__dirname, '..');
+const skillModule = 'installation/skills.js';
+const staleSkillArtifactsPattern =
+  /const STALE_SKILL_ARTIFACTS = Object\.freeze\(\{\r?\n[\s\S]*?\r?\n\}\);\r?\n/;
+
+function sourceWithoutStaleSkillArtifacts(filename, source) {
+  if (filename !== skillModule) return source;
+  assert.match(source, staleSkillArtifactsPattern, 'skill migration data must stay explicitly bounded');
+  return source.replace(staleSkillArtifactsPattern, '');
+}
 
 test('npm launcher modules are grouped into folders of at most ten files', () => {
   const pending = [libRoot];
@@ -36,7 +45,8 @@ test('npm launcher modules are grouped into folders of at most ten files', () =>
 test('npm installer modules contain only canonical Kaboom identities', () => {
   for (const filename of canonicalModules) {
     const source = fs.readFileSync(path.join(libRoot, filename), 'utf8');
-    assert.doesNotMatch(source, /\b(?:gasoline|strum)\b/i, `${filename} retains an old-brand shim`);
+    const canonicalSource = sourceWithoutStaleSkillArtifacts(filename, source);
+    assert.doesNotMatch(canonicalSource, /\b(?:gasoline|strum)\b/i, `${filename} retains an old-brand shim`);
     assert.doesNotMatch(source, /\bLEGACY_/i, `${filename} retains a compatibility branch`);
     assert.doesNotMatch(source, /\blegacyConfig(?:Keys|Paths)\b/, `${filename} retains an old config boundary`);
     assert.doesNotMatch(
@@ -45,4 +55,25 @@ test('npm installer modules contain only canonical Kaboom identities', () => {
       `${filename} retains obsolete legacy reporting`
     );
   }
+});
+
+test('retired skill identities are bounded, non-exported artifact cleanup data', () => {
+  const source = fs.readFileSync(path.join(libRoot, skillModule), 'utf8');
+  const artifactData = source.match(staleSkillArtifactsPattern)?.[0] || '';
+
+  assert.match(artifactData, /\bgasoline\b/i);
+  assert.match(artifactData, /\bstrum\b/i);
+  assert.doesNotMatch(source.match(/module\.exports = \{[\s\S]*?\n\};/)?.[0] || '', /STALE_SKILL_ARTIFACTS/);
+  assert.match(source, /function removeStaleFlatSkillFiles\(/);
+  assert.match(source, /fs\.unlinkSync\(stalePath\)/);
+});
+
+test('retired skill artifact boundaries are portable across checkout line endings', () => {
+  const source = fs.readFileSync(path.join(libRoot, skillModule), 'utf8');
+  const windowsSource = source.replace(/\r?\n/g, '\r\n');
+
+  assert.doesNotMatch(
+    sourceWithoutStaleSkillArtifacts(skillModule, windowsSource),
+    /\b(?:gasoline|strum)\b/i
+  );
 });

--- a/npm/kaboom-agentic-browser/lib/installation/install.test.js
+++ b/npm/kaboom-agentic-browser/lib/installation/install.test.js
@@ -15,6 +15,8 @@ const {
 } = require('./install');
 const { installBundledSkills } = require('./skills');
 
+const TEST_BINARY_COMMAND = process.execPath;
+
 test('npm wrapper metadata uses kaboom package and launcher names', () => {
   const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf8'));
   assert.equal(packageJson.name, 'kaboom-agentic-browser');
@@ -40,7 +42,7 @@ test('npm wrapper readme and launcher copy use kaboom branding', () => {
 // --- generateDefaultConfig ---
 
 test('generateDefaultConfig returns valid MCP config', () => {
-  const cfg = generateDefaultConfig();
+  const cfg = generateDefaultConfig({ binaryCommand: TEST_BINARY_COMMAND });
   assert.ok(cfg.mcpServers);
   assert.ok(cfg.mcpServers['kaboom-browser-devtools']);
   assert.ok(cfg.mcpServers['kaboom-browser-devtools'].command.length > 0);
@@ -54,14 +56,14 @@ test('generateDefaultConfig honors binaryCommand override', () => {
 // --- buildMcpEntry ---
 
 test('buildMcpEntry returns JSON string for MCP entry', () => {
-  const entry = buildMcpEntry();
+  const entry = buildMcpEntry({}, { binaryCommand: TEST_BINARY_COMMAND });
   const parsed = JSON.parse(entry);
   assert.ok(parsed.command.length > 0);
   assert.deepEqual(parsed.args, []);
 });
 
 test('buildMcpEntry includes env vars when provided', () => {
-  const entry = buildMcpEntry({ DEBUG: '1' });
+  const entry = buildMcpEntry({ DEBUG: '1' }, { binaryCommand: TEST_BINARY_COMMAND });
   const parsed = JSON.parse(entry);
   assert.equal(parsed.env.DEBUG, '1');
 });
@@ -115,7 +117,11 @@ test('installToClient merges into existing file-type config', () => {
     detectDir: { all: tmp },
   };
 
-  const result = installToClient(def, { dryRun: false, envVars: {} });
+  const result = installToClient(def, {
+    dryRun: false,
+    envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
+  });
   assert.equal(result.success, true);
   assert.equal(result.isNew, false);
 
@@ -138,7 +144,11 @@ test('installToClient dry-run does not write file', () => {
     detectDir: { all: tmp },
   };
 
-  const result = installToClient(def, { dryRun: true, envVars: {} });
+  const result = installToClient(def, {
+    dryRun: true,
+    envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
+  });
   assert.equal(result.success, true);
   assert.equal(fs.existsSync(cfgPath), false, 'should not create file in dry-run');
 
@@ -157,7 +167,11 @@ test('installToClient adds env vars to file-type config', () => {
     detectDir: { all: tmp },
   };
 
-  installToClient(def, { dryRun: false, envVars: { DEBUG: '1' } });
+  installToClient(def, {
+    dryRun: false,
+    envVars: { DEBUG: '1' },
+    binaryCommand: TEST_BINARY_COMMAND,
+  });
   const written = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
   assert.equal(written.mcpServers['kaboom-browser-devtools'].env.DEBUG, '1');
 
@@ -175,7 +189,11 @@ test('installToClient handles CLI type with dry-run', () => {
     installArgs: ['mcp', 'add-json', '--scope', 'user', 'kaboom-browser-devtools'],
   };
 
-  const result = installToClient(def, { dryRun: true, envVars: {} });
+  const result = installToClient(def, {
+    dryRun: true,
+    envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
+  });
   assert.equal(result.success, true);
   assert.equal(result.method, 'cli');
   assert.ok(result.message.includes('claude'));
@@ -235,6 +253,7 @@ test('executeInstall installs to detected file-type clients', () => {
   const result = executeInstall({
     dryRun: false,
     envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
     _clientOverrides: [
       {
         id: 'test-cursor',
@@ -257,6 +276,7 @@ test('executeInstall reports when no clients detected', () => {
   const result = executeInstall({
     dryRun: false,
     envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
     _clientOverrides: [],
   });
 
@@ -276,6 +296,7 @@ test('executeInstall with targetTool installs to specific client', () => {
   const result = executeInstall({
     dryRun: false,
     envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
     _clientOverrides: [
       {
         id: 'test-gemini',
@@ -301,6 +322,7 @@ test('executeInstall with invalid targetTool returns error', () => {
   const result = executeInstall({
     dryRun: false,
     envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
     targetTool: 'bogus',
   });
 
@@ -451,6 +473,7 @@ test('executeInstall dry-run reports all detected clients without writing', () =
   const result = executeInstall({
     dryRun: true,
     envVars: {},
+    binaryCommand: TEST_BINARY_COMMAND,
     _clientOverrides: [
       {
         id: 'test-cursor',

--- a/npm/kaboom-agentic-browser/lib/installation/skills.js
+++ b/npm/kaboom-agentic-browser/lib/installation/skills.js
@@ -14,6 +14,11 @@ const os = require('os');
 const path = require('path');
 
 const MANAGED_MARKER = '<!-- kaboom-managed-skill';
+const STALE_SKILL_ARTIFACTS = Object.freeze({
+  prefixes: Object.freeze(['kaboom-', 'gasoline-', 'strum-']),
+  markers: Object.freeze(['<!-- gasoline-managed-skill', '<!-- strum-managed-skill']),
+});
+const MANAGED_MARKERS = Object.freeze([MANAGED_MARKER, ...STALE_SKILL_ARTIFACTS.markers]);
 const BUNDLED_SKILLS_DIR = path.join(__dirname, '..', '..', 'skills');
 const DEFAULT_AGENTS = ['claude', 'codex', 'gemini'];
 
@@ -409,7 +414,7 @@ async function loadSkillCatalog(options = {}) {
 
 function buildManagedContent(agent, skillId, version, body) {
   const marker = `${MANAGED_MARKER} id:${skillId} version:${version} -->`;
-  if (agent !== 'codex' || !body.startsWith('---\n')) {
+  if (!usesDirectorySkillLayout(agent) || !body.startsWith('---\n')) {
     return `${marker}\n${body}`;
   }
   const frontmatterEnd = body.indexOf('\n---\n', 4);
@@ -421,7 +426,7 @@ function buildManagedContent(agent, skillId, version, body) {
 }
 
 function isManagedSkillContent(content) {
-  return content.includes(MANAGED_MARKER);
+  return isManagedSkillFileStart(content);
 }
 
 function safeWriteManagedFile(filePath, content) {
@@ -454,11 +459,55 @@ function safeWriteManagedFile(filePath, content) {
   }
 }
 
+function usesDirectorySkillLayout(agent) {
+  return agent === 'codex' || agent === 'claude';
+}
+
 function skillFilePath(agent, rootDir, skillId) {
-  if (agent === 'codex') {
+  if (usesDirectorySkillLayout(agent)) {
     return path.join(rootDir, skillId, 'SKILL.md');
   }
   return path.join(rootDir, `${skillId}.md`);
+}
+
+function staleFlatSkillPaths(agent, rootDir, skillId) {
+  if (!usesDirectorySkillLayout(agent)) return [];
+  const names = [`${skillId}.md`];
+  for (const prefix of STALE_SKILL_ARTIFACTS.prefixes) {
+    names.push(`${prefix}${skillId}.md`);
+  }
+  return names.map((name) => path.join(rootDir, name));
+}
+
+function removeStaleFlatSkillFiles(agent, rootDir, skillId, options = {}) {
+  const { dryRun = false } = options;
+  const result = { removed: 0, errors: 0 };
+  for (const stalePath of staleFlatSkillPaths(agent, rootDir, skillId)) {
+    if (!fs.existsSync(stalePath)) continue;
+    try {
+      const existing = fs.readFileSync(stalePath, 'utf8');
+      if (!isManagedSkillContent(existing)) continue;
+      if (!dryRun) fs.unlinkSync(stalePath);
+      result.removed += 1;
+    } catch (err) {
+      result.errors += 1;
+    }
+  }
+  return result;
+}
+
+function removeEmptySkillDirectory(managedPath, result) {
+  if (path.basename(managedPath) !== 'SKILL.md') return;
+  try {
+    fs.rmdirSync(path.dirname(managedPath));
+  } catch (err) {
+    if (err && (err.code === 'ENOENT' || err.code === 'ENOTEMPTY')) {
+      // EXPECTED_ABSENCE: a missing directory is already clean, while a non-empty
+      // directory contains user-owned sidecars that cleanup must preserve.
+      return;
+    }
+    result.errors += 1;
+  }
 }
 
 function removeManagedSkillFile(agent, rootDir, skillId, options = {}) {
@@ -475,14 +524,7 @@ function removeManagedSkillFile(agent, rootDir, skillId, options = {}) {
     }
     if (!dryRun) {
       fs.unlinkSync(managedPath);
-      if (agent === 'codex') {
-        const managedDir = path.dirname(managedPath);
-        try {
-          fs.rmdirSync(managedDir);
-        } catch (err) {
-          // Ignore non-empty or missing directory errors.
-        }
-      }
+      removeEmptySkillDirectory(managedPath, result);
     }
     result.removed += 1;
     return result;
@@ -494,16 +536,13 @@ function removeManagedSkillFile(agent, rootDir, skillId, options = {}) {
 
 function isManagedSkillFileStart(content) {
   const text = String(content || '');
-  if (text.startsWith(MANAGED_MARKER)) return true;
-  if (!text.startsWith('---\n')) return false;
-  const frontmatterEnd = text.indexOf('\n---\n', 4);
-  return frontmatterEnd >= 0 && text.startsWith(MANAGED_MARKER, frontmatterEnd + 5);
+  return MANAGED_MARKERS.some((marker) => text.startsWith(marker) || text.includes(`\n${marker}`));
 }
 
 /**
  * Remove managed skill files that are no longer in the bundled manifest
- * (renamed or dropped skills). Only files whose content STARTS with a managed
- * marker are removed — user-owned files are never touched.
+ * (renamed or dropped skills). Only files with a managed marker at a line
+ * start are removed — user-owned files are never touched.
  * handledPaths lists files already processed by the manifest-based cleanup so
  * dry-run counts are not duplicated.
  */
@@ -513,14 +552,23 @@ function removeOrphanedManagedSkills(agent, rootDir, handledPaths, options = {})
   let entries;
   try {
     entries = fs.readdirSync(rootDir, { withFileTypes: true });
-  } catch (_) {
-    return result; // Root does not exist — nothing to clean.
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      // EXPECTED_ABSENCE: an agent without a skill root has nothing to clean.
+      return result;
+    }
+    result.errors += 1;
+    return result;
   }
 
   for (const entry of entries) {
     let candidate = null;
-    if (agent === 'codex') {
-      if (entry.isDirectory()) candidate = path.join(rootDir, entry.name, 'SKILL.md');
+    if (usesDirectorySkillLayout(agent)) {
+      if (entry.isDirectory()) {
+        candidate = path.join(rootDir, entry.name, 'SKILL.md');
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        candidate = path.join(rootDir, entry.name);
+      }
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
       candidate = path.join(rootDir, entry.name);
     }
@@ -531,16 +579,10 @@ function removeOrphanedManagedSkills(agent, rootDir, handledPaths, options = {})
       if (!isManagedSkillFileStart(content)) continue;
       if (!dryRun) {
         fs.unlinkSync(candidate);
-        if (agent === 'codex') {
-          try {
-            fs.rmdirSync(path.dirname(candidate));
-          } catch (_) {
-            // Ignore non-empty or missing directory errors.
-          }
-        }
+        removeEmptySkillDirectory(candidate, result);
       }
       result.removed += 1;
-    } catch (_) {
+    } catch (err) {
       result.errors += 1;
     }
   }
@@ -606,6 +648,7 @@ async function installBundledSkills(options = {}) {
         updated: 0,
         unchanged: 0,
         skipped_user_owned: 0,
+        removed: 0,
         errors: 0,
       },
       results: [],
@@ -626,6 +669,7 @@ async function installBundledSkills(options = {}) {
         updated: 0,
         unchanged: 0,
         skipped_user_owned: 0,
+        removed: 0,
         errors: 0,
       },
       results: [],
@@ -641,6 +685,7 @@ async function installBundledSkills(options = {}) {
     updated: 0,
     unchanged: 0,
     skipped_user_owned: 0,
+    removed: 0,
     errors: 0,
   };
 
@@ -671,6 +716,9 @@ async function installBundledSkills(options = {}) {
             `[kaboom-mcp] skills ${writeResult.status}: ${agent}:${skill.id} -> ${filePath}${suffix}`
           );
         }
+        const stale = removeStaleFlatSkillFiles(agent, rootDir, skill.id);
+        summary.removed += stale.removed;
+        summary.errors += stale.errors;
       }
     }
   }

--- a/npm/kaboom-agentic-browser/lib/installation/skills.test.js
+++ b/npm/kaboom-agentic-browser/lib/installation/skills.test.js
@@ -90,6 +90,26 @@ test('installBundledSkills preserves Codex frontmatter as the first document blo
   }
 });
 
+test('installBundledSkills writes Claude skills as <id>/SKILL.md with frontmatter first', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-claude-frontmatter-'));
+  try {
+    const claudeRoot = path.join(tmp, 'claude-skills');
+    const skillsDir = makeSkillsFixture(tmp);
+    const result = await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: claudeRoot }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir })
+    );
+
+    assert.equal(result.summary.created, 1);
+    const skillPath = path.join(claudeRoot, 'demo', 'SKILL.md');
+    const content = fs.readFileSync(skillPath, 'utf8');
+    assert.match(content, /^---\nname: demo\ndescription: Demo skill\.\n---\n/);
+    assert.match(content, /\n<!-- kaboom-managed-skill id:demo version:3 -->\n# Demo/);
+    assert.equal(fs.existsSync(path.join(claudeRoot, 'demo.md')), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // --- isAgentRootInstallable (regression: postinstall fabricated ~/.gemini etc.) ---
 
 test('isAgentRootInstallable requires the agent parent dir to already exist', () => {
@@ -140,7 +160,7 @@ test('installBundledSkills only installs into agent dirs that already exist', as
 
     assert.equal(result.skipped, false);
     assert.equal(
-      fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'demo.md')),
+      fs.existsSync(path.join(projectRoot, '.claude', 'skills', 'demo', 'SKILL.md')),
       true,
       'must install into the existing .claude layout'
     );
@@ -166,7 +186,7 @@ test('installBundledSkills force-creates explicit env-var skill targets', async 
 
     assert.equal(result.skipped, false);
     assert.equal(
-      fs.existsSync(path.join(forcedRoot, 'demo.md')),
+      fs.existsSync(path.join(forcedRoot, 'demo', 'SKILL.md')),
       true,
       'explicit env-var target must be created even when its parent did not exist'
     );
@@ -181,10 +201,16 @@ test('cleanupInstalledSkills removes managed skills no longer in the manifest', 
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-orphan-'));
   try {
     const claudeRoot = path.join(tmp, 'claude-skills');
-    fs.mkdirSync(claudeRoot, { recursive: true });
+    fs.mkdirSync(path.join(claudeRoot, 'old-renamed-skill'), { recursive: true });
     fs.writeFileSync(
-      path.join(claudeRoot, 'old-renamed-skill.md'),
-      '<!-- kaboom-managed-skill id:old-renamed-skill version:1 -->\nrenamed away\n',
+      path.join(claudeRoot, 'old-renamed-skill', 'SKILL.md'),
+      '---\nname: old-renamed-skill\n---\nrenamed away\n' +
+        '<!-- kaboom-managed-skill id:old-renamed-skill version:1 -->\n',
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(claudeRoot, 'gasoline-ancient.md'),
+      '<!-- gasoline-managed-skill id:ancient version:1 -->\nold era\n',
       'utf8'
     );
     fs.writeFileSync(path.join(claudeRoot, 'user-note.md'), '# my own skill\n', 'utf8');
@@ -198,8 +224,9 @@ test('cleanupInstalledSkills removes managed skills no longer in the manifest', 
       cleanupInstalledSkills({ agents: ['claude'], scope: 'global' })
     );
 
-    assert.ok(result.removed >= 1, `expected orphaned managed skills removed, got ${result.removed}`);
-    assert.equal(fs.existsSync(path.join(claudeRoot, 'old-renamed-skill.md')), false);
+    assert.equal(result.removed, 2, `expected both managed skill layouts removed, got ${result.removed}`);
+    assert.equal(fs.existsSync(path.join(claudeRoot, 'old-renamed-skill')), false);
+    assert.equal(fs.existsSync(path.join(claudeRoot, 'gasoline-ancient.md')), false);
     assert.equal(fs.existsSync(path.join(claudeRoot, 'user-note.md')), true, 'user files must survive');
     assert.equal(
       fs.existsSync(path.join(claudeRoot, 'mentions-marker.md')),
@@ -240,11 +267,11 @@ test('cleanupInstalledSkills dry-run counts orphans without deleting and without
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-orphan-dry-'));
   try {
     const claudeRoot = path.join(tmp, 'claude-skills');
-    fs.mkdirSync(claudeRoot, { recursive: true });
+    fs.mkdirSync(path.join(claudeRoot, 'debug'), { recursive: true });
     // One manifest-known skill + one orphan.
     fs.writeFileSync(
-      path.join(claudeRoot, 'debug.md'),
-      '<!-- kaboom-managed-skill id:debug version:1 -->\ncurrent\n',
+      path.join(claudeRoot, 'debug', 'SKILL.md'),
+      '---\nname: debug\n---\ncurrent\n<!-- kaboom-managed-skill id:debug version:1 -->\n',
       'utf8'
     );
     fs.writeFileSync(
@@ -258,8 +285,105 @@ test('cleanupInstalledSkills dry-run counts orphans without deleting and without
     );
 
     assert.equal(result.removed, 2, 'dry-run must count each managed file exactly once');
-    assert.equal(fs.existsSync(path.join(claudeRoot, 'debug.md')), true);
+    assert.equal(fs.existsSync(path.join(claudeRoot, 'debug', 'SKILL.md')), true);
     assert.equal(fs.existsSync(path.join(claudeRoot, 'orphan.md')), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills reclaims every managed flat Claude variant', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-flat-migration-'));
+  try {
+    const claudeRoot = path.join(tmp, 'claude-skills');
+    fs.mkdirSync(claudeRoot, { recursive: true });
+    const staleFiles = [
+      ['demo.md', 'kaboom'],
+      ['kaboom-demo.md', 'kaboom'],
+      ['gasoline-demo.md', 'gasoline'],
+      ['strum-demo.md', 'strum'],
+    ];
+    for (const [filename, markerBrand] of staleFiles) {
+      fs.writeFileSync(
+        path.join(claudeRoot, filename),
+        `<!-- ${markerBrand}-managed-skill id:demo version:1 -->\nold\n`,
+        'utf8'
+      );
+    }
+
+    const result = await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: claudeRoot }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir: makeSkillsFixture(tmp) })
+    );
+
+    assert.equal(result.summary.removed, staleFiles.length);
+    for (const [filename] of staleFiles) {
+      assert.equal(fs.existsSync(path.join(claudeRoot, filename)), false, `${filename} must be reclaimed`);
+    }
+    assert.equal(fs.existsSync(path.join(claudeRoot, 'demo', 'SKILL.md')), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills preserves user-authored flat Claude variants', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-flat-user-owned-'));
+  try {
+    const claudeRoot = path.join(tmp, 'claude-skills');
+    fs.mkdirSync(claudeRoot, { recursive: true });
+    const userFiles = [
+      ['demo.md', 'kaboom'],
+      ['kaboom-demo.md', 'kaboom'],
+      ['gasoline-demo.md', 'gasoline'],
+      ['strum-demo.md', 'strum'],
+    ];
+    for (const [filename, markerBrand] of userFiles) {
+      fs.writeFileSync(
+        path.join(claudeRoot, filename),
+        `# User skill: ${filename}\nDocs mention <!-- ${markerBrand}-managed-skill inline.\n`,
+        'utf8'
+      );
+    }
+
+    const result = await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: claudeRoot }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir: makeSkillsFixture(tmp) })
+    );
+
+    assert.equal(result.summary.removed, 0);
+    for (const [filename] of userFiles) {
+      assert.equal(fs.existsSync(path.join(claudeRoot, filename)), true, `${filename} is user-owned`);
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills reports stale Claude cleanup failures', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-flat-error-'));
+  try {
+    const claudeRoot = path.join(tmp, 'claude-skills');
+    fs.mkdirSync(path.join(claudeRoot, 'demo.md'), { recursive: true });
+
+    const result = await withEnv({ KABOOM_CLAUDE_SKILLS_DIR: claudeRoot }, () =>
+      installBundledSkills({ agents: ['claude'], scope: 'global', skillsDir: makeSkillsFixture(tmp) })
+    );
+
+    assert.equal(result.summary.errors, 1, 'unexpected stale-file errors must not be discarded');
+    assert.equal(fs.existsSync(path.join(claudeRoot, 'demo', 'SKILL.md')), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('installBundledSkills leaves Gemini on its flat layout', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-gemini-layout-'));
+  try {
+    const geminiRoot = path.join(tmp, 'gemini-skills');
+    await withEnv({ KABOOM_GEMINI_SKILLS_DIR: geminiRoot }, () =>
+      installBundledSkills({ agents: ['gemini'], scope: 'global', skillsDir: makeSkillsFixture(tmp) })
+    );
+
+    assert.equal(fs.existsSync(path.join(geminiRoot, 'demo.md')), true);
+    assert.equal(fs.existsSync(path.join(geminiRoot, 'demo', 'SKILL.md')), false);
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/npm/kaboom-agentic-browser/lib/installation/uninstall.test.js
+++ b/npm/kaboom-agentic-browser/lib/installation/uninstall.test.js
@@ -349,10 +349,12 @@ test('executeUninstall removes from detected file-type clients', () => {
 test('executeUninstall removes canonical managed skill files', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-uninstall-'));
   const claudeRoot = path.join(tmp, 'claude-skills');
-  fs.mkdirSync(claudeRoot, { recursive: true });
+  const skillPath = path.join(claudeRoot, 'debug', 'SKILL.md');
+  fs.mkdirSync(path.dirname(skillPath), { recursive: true });
   fs.writeFileSync(
-    path.join(claudeRoot, 'debug.md'),
-    '<!-- kaboom-managed-skill id:debug version:2 -->\ncurrent kaboom skill\n',
+    skillPath,
+    '---\nname: debug\n---\ncurrent kaboom skill\n' +
+      '<!-- kaboom-managed-skill id:debug version:2 -->\n',
     'utf8'
   );
 
@@ -369,7 +371,7 @@ test('executeUninstall removes canonical managed skill files', () => {
     assert.equal(result.success, true);
     assert.ok(result.skillCleanup);
     assert.equal(result.skillCleanup.removed, 1);
-    assert.equal(fs.existsSync(path.join(claudeRoot, 'debug.md')), false);
+    assert.equal(fs.existsSync(path.join(claudeRoot, 'debug')), false);
   } finally {
     if (originalClaudeDir === undefined) {
       delete process.env.KABOOM_CLAUDE_SKILLS_DIR;

--- a/npm/kaboom-agentic-browser/lib/runtime/resolve-binary.test.js
+++ b/npm/kaboom-agentic-browser/lib/runtime/resolve-binary.test.js
@@ -14,8 +14,8 @@ const {
   HOOKS_BINARY,
 } = require('./resolve-binary');
 
-const INSTALLED_ROOT = path.join(path.sep, 'proj', 'node_modules', 'kaboom-agentic-browser');
-const SOURCE_ROOT = path.join(path.sep, 'repo', 'npm', 'kaboom-agentic-browser');
+const INSTALLED_ROOT = path.resolve(path.sep, 'proj', 'node_modules', 'kaboom-agentic-browser');
+const SOURCE_ROOT = path.resolve(path.sep, 'repo', 'npm', 'kaboom-agentic-browser');
 
 function resolve(overrides = {}) {
   return resolveBinary({

--- a/scripts/quality/contracts/check-bridge-stdout-invariant.sh
+++ b/scripts/quality/contracts/check-bridge-stdout-invariant.sh
@@ -28,7 +28,7 @@ for file in "${TARGET_FILES[@]}"; do
     VIOLATIONS=1
     continue
   fi
-  if rg -n "$PATTERN" "$file" >/tmp/kaboom-stdout-invariant.tmp 2>/dev/null; then
+  if grep -En -- "$PATTERN" "$file" >/tmp/kaboom-stdout-invariant.tmp 2>/dev/null; then
     echo "INVARIANT VIOLATION: direct stdout write in $file"
     cat /tmp/kaboom-stdout-invariant.tmp
     VIOLATIONS=1
@@ -36,17 +36,17 @@ for file in "${TARGET_FILES[@]}"; do
 done
 rm -f /tmp/kaboom-stdout-invariant.tmp
 
-if ! rg -n 'bridgeRunner\.EnsureIOIsolation\(config\.logFile\)' cmd/browser-agent/config.go >/dev/null 2>&1; then
+if ! grep -En -- 'server\.runtime\.BridgeRunner\(\)\.EnsureIOIsolation\(config\.LogFile\)' cmd/browser-agent/config.go >/dev/null 2>&1; then
   echo "INVARIANT VIOLATION: bridge mode must initialize IO isolation through its constructed runner in config.go"
   VIOLATIONS=1
 fi
 
-if ! rg -n 'bridge\.SendStartupError\("Bridge stdio isolation failed:' cmd/browser-agent/config.go >/dev/null 2>&1; then
+if ! grep -En -- 'bridge\.SendStartupError\("Bridge stdio isolation failed:' cmd/browser-agent/config.go >/dev/null 2>&1; then
   echo "INVARIANT VIOLATION: bridge isolation failures must be surfaced as JSON-RPC startup errors"
   VIOLATIONS=1
 fi
 
-if ! rg -n 'syscall\.CloseOnExec\(fd\)' cmd/browser-agent/internal/bridge/stdioisolate/isolation_unix.go >/dev/null 2>&1; then
+if ! grep -En -- 'syscall\.CloseOnExec\(fd\)' cmd/browser-agent/internal/bridge/stdioisolate/isolation_unix.go >/dev/null 2>&1; then
   echo "INVARIANT VIOLATION: duplicated MCP transport fd must be marked close-on-exec"
   VIOLATIONS=1
 fi

--- a/scripts/setup/install-bundled-skills.sh
+++ b/scripts/setup/install-bundled-skills.sh
@@ -106,11 +106,16 @@ skill_dest_path() {
   local agent="$1"
   local root="$2"
   local skill_id="$3"
-  if [ "$agent" = "codex" ]; then
+  if uses_directory_skill_layout "$agent"; then
     printf "%s\n" "$root/$skill_id/SKILL.md"
   else
     printf "%s\n" "$root/$skill_id.md"
   fi
+}
+
+uses_directory_skill_layout() {
+  local agent="$1"
+  [ "$agent" = "claude" ] || [ "$agent" = "codex" ]
 }
 
 install_skill() {
@@ -131,7 +136,7 @@ install_skill() {
   local tmp_file
   tmp_file="$(mktemp)"
   local managed_marker="$MARKER id:$skill_id version:$version -->"
-  if [ "$agent" = "codex" ] && [ "$(head -n 1 "$src_file")" = "---" ]; then
+  if uses_directory_skill_layout "$agent" && [ "$(head -n 1 "$src_file")" = "---" ]; then
     awk -v marker="$managed_marker" '
       { print }
       NR > 1 && $0 == "---" && !inserted {

--- a/tests/cli/lifecycle/install.test.cjs
+++ b/tests/cli/lifecycle/install.test.cjs
@@ -6,6 +6,8 @@ const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const STALE_SKILL_ARTIFACTS_PATTERN =
+  /const STALE_SKILL_ARTIFACTS = Object\.freeze\(\{[\s\S]*?\n\}\);\n/
 const PLATFORM_PACKAGES = [
   ['darwin-arm64', '@brennhill/kaboom-agentic-browser-darwin-arm64'],
   ['darwin-x64', '@brennhill/kaboom-agentic-browser-darwin-x64'],
@@ -47,7 +49,11 @@ test('npm skill installer targets only canonical kaboom-managed output', () => {
   )
 
   assert.match(skillsSource, /kaboom-managed-skill/)
-  assert.doesNotMatch(skillsSource, /\b(?:gasoline|strum|legacy)\b/i)
+  assert.match(skillsSource, STALE_SKILL_ARTIFACTS_PATTERN)
+  assert.doesNotMatch(
+    skillsSource.replace(STALE_SKILL_ARTIFACTS_PATTERN, ''),
+    /\b(?:gasoline|strum|legacy)\b/i
+  )
   assert.match(postinstallSource, /\[kaboom-mcp\]/)
 })
 
@@ -95,12 +101,12 @@ test('install-bundled-skills.sh uses per-skill manifest versions and manifest it
     })
     assert.equal(res.status, 0, `script failed:\nstdout: ${res.stdout}\nstderr: ${res.stderr}`)
 
-    const alpha = fs.readFileSync(path.join(claudeRoot, 'alpha.md'), 'utf8')
-    const beta = fs.readFileSync(path.join(claudeRoot, 'beta.md'), 'utf8')
+    const alpha = fs.readFileSync(path.join(claudeRoot, 'alpha', 'SKILL.md'), 'utf8')
+    const beta = fs.readFileSync(path.join(claudeRoot, 'beta', 'SKILL.md'), 'utf8')
     assert.match(alpha, /^<!-- kaboom-managed-skill id:alpha version:1 -->/, 'alpha must carry manifest version 1')
     assert.match(beta, /^<!-- kaboom-managed-skill id:beta version:2 -->/, 'beta must carry manifest version 2, not a hardcoded 1')
     assert.equal(
-      fs.existsSync(path.join(claudeRoot, 'not-in-manifest.md')),
+      fs.existsSync(path.join(claudeRoot, 'not-in-manifest', 'SKILL.md')),
       false,
       'must only install manifest-listed skills, not every directory'
     )
@@ -127,13 +133,14 @@ test('install-bundled-skills.sh markers match the real bundled manifest versions
       fs.readFileSync(path.join(REPO_ROOT, 'npm/kaboom-agentic-browser/skills/skills.json'), 'utf8')
     )
     for (const skill of manifest.skills) {
-      const installed = path.join(claudeRoot, `${skill.id}.md`)
+      const installed = path.join(claudeRoot, skill.id, 'SKILL.md')
       assert.ok(fs.existsSync(installed), `manifest skill ${skill.id} must be installed`)
       const content = fs.readFileSync(installed, 'utf8')
       const expectedVersion = skill.version || 1
+      assert.match(content, /^---\n/, `${skill.id} must retain frontmatter on line 1`)
       assert.match(
         content,
-        new RegExp(`^<!-- kaboom-managed-skill id:${skill.id} version:${expectedVersion} -->`),
+        new RegExp(`\n<!-- kaboom-managed-skill id:${skill.id} version:${expectedVersion} -->\n`),
         `${skill.id} marker version must match the manifest (shell/npm installs must not fight)`
       )
     }
@@ -142,21 +149,44 @@ test('install-bundled-skills.sh markers match the real bundled manifest versions
   }
 })
 
-test('install-bundled-skills.sh keeps Codex YAML frontmatter first', () => {
+test('install-bundled-skills.sh keeps Claude and Codex YAML frontmatter first', () => {
   if (process.platform === 'win32') return
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-sh-codex-'))
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-sh-directory-'))
   try {
-    const codexRoot = path.join(tmp, 'codex-skills')
+    for (const [agent, envName] of [
+      ['claude', 'KABOOM_CLAUDE_SKILLS_DIR'],
+      ['codex', 'KABOOM_CODEX_SKILLS_DIR'],
+    ]) {
+      const root = path.join(tmp, `${agent}-skills`)
+      const res = runSkillsScript({
+        [envName]: root,
+        KABOOM_SKILL_TARGETS: agent,
+        KABOOM_SKILL_SCOPE: 'global',
+      })
+      assert.equal(res.status, 0, `script failed:\nstdout: ${res.stdout}\nstderr: ${res.stderr}`)
+
+      const content = fs.readFileSync(path.join(root, 'debug', 'SKILL.md'), 'utf8')
+      assert.match(content, /^---\n/, `${agent} requires YAML frontmatter on the first line`)
+      assert.match(content, /\n<!-- kaboom-managed-skill id:debug version:\d+ -->\n/)
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('install-bundled-skills.sh leaves Gemini on its flat layout', () => {
+  if (process.platform === 'win32') return
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-skills-sh-gemini-'))
+  try {
+    const geminiRoot = path.join(tmp, 'gemini-skills')
     const res = runSkillsScript({
-      KABOOM_CODEX_SKILLS_DIR: codexRoot,
-      KABOOM_SKILL_TARGETS: 'codex',
+      KABOOM_GEMINI_SKILLS_DIR: geminiRoot,
+      KABOOM_SKILL_TARGETS: 'gemini',
       KABOOM_SKILL_SCOPE: 'global',
     })
     assert.equal(res.status, 0, `script failed:\nstdout: ${res.stdout}\nstderr: ${res.stderr}`)
-
-    const content = fs.readFileSync(path.join(codexRoot, 'debug', 'SKILL.md'), 'utf8')
-    assert.match(content, /^---\n/, 'Codex requires YAML frontmatter on the first line')
-    assert.match(content, /\n<!-- kaboom-managed-skill id:debug version:\d+ -->\n/)
+    assert.equal(fs.existsSync(path.join(geminiRoot, 'debug.md')), true)
+    assert.equal(fs.existsSync(path.join(geminiRoot, 'debug', 'SKILL.md')), false)
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }

--- a/tests/extension/contracts/tooling-contracts.test.js
+++ b/tests/extension/contracts/tooling-contracts.test.js
@@ -182,6 +182,24 @@ describe('Tooling contracts', () => {
     }
   })
 
+  test('scoped verify-llm CI installs the pinned Node toolchain before running the gate', () => {
+    const ci = readFileSync('.github/workflows/ci.yml', 'utf8')
+    const verifyJob = ci.match(/^ {2}verify-llm:[\s\S]*?(?=^ {2}[a-z][\w-]*:)/m)?.[0] || ''
+
+    assert.match(
+      verifyJob,
+      /name: Install pinned Node toolchain\s*\n\s*if: steps\.scope\.outputs\.run_gate == 'true'\s*\n\s*run: npm ci/
+    )
+    assert.match(verifyJob, /name: Install pinned Node toolchain[\s\S]*name: Run verify-llm gate/)
+  })
+
+  test('bridge stdout invariant uses a search command available on minimal hosted runners', () => {
+    const invariant = readFileSync('scripts/quality/contracts/check-bridge-stdout-invariant.sh', 'utf8')
+
+    assert.doesNotMatch(invariant, /\brg\b/)
+    assert.match(invariant, /grep -En --/)
+  })
+
   test('scheduled and pull-request fuzzing share the canonical bounded campaign owner', () => {
     const makefile = readFileSync('Makefile', 'utf8')
     const ci = readFileSync('.github/workflows/ci.yml', 'utf8')


### PR DESCRIPTION
## Summary

Follow-up to #697, ported onto the current `UNSTABLE` installer architecture and resolving every unresolved review thread:

- install Claude skills at `<root>/<id>/SKILL.md` with YAML frontmatter on line 1
- reclaim and count managed flat Claude files from the unprefixed, `kaboom-`, `gasoline-`, and `strum-` layouts
- preserve user-authored files, including files that merely mention a managed marker inline
- surface stale-file cleanup failures through the install summary
- update canonical install/uninstall assertions and keep Gemini flat
- align the source installer with the npm installer for Claude and Codex
- update the enhanced CLI feature cross-reference and `last_reviewed`
- make clean-checkout installer tests deterministic and Windows-portable
- repair the scoped `verify-llm` setup plus the schema-reference and bridge-invariant drift it exposed

Retired names remain bounded, non-exported artifact-ownership data used only to clean up files; no compatibility facade or callable old surface is restored.

## Review threads addressed

- https://github.com/brennhill/Kaboom-Browser-AI-Devtools-MCP/pull/697#discussion_r3882616351
- https://github.com/brennhill/Kaboom-Browser-AI-Devtools-MCP/pull/697#discussion_r3882616357
- https://github.com/brennhill/Kaboom-Browser-AI-Devtools-MCP/pull/697#discussion_r3882616364

## Verification

- npm wrapper suite: 235 passed
- clean-environment targeted installer/contracts/tooling suite: 47 passed
- `make verify-llm`: passed
- ESLint and TypeScript typecheck: passed
- structure and duplicate gates: passed
- strict docs checks: passed with 0 errors (existing warning backlog unchanged)
- secrets, wire drift, and TS strictness gates: passed
- `make test`: all changed-path tests and all Go suites passed; two unrelated parallel timing flakes each passed immediately in isolation and are tracked as `kaboom-uni6` and `kaboom-awsk`

Bead: `kaboom-xz2p`
